### PR TITLE
[Bugfix] Used chromium instances were not being swept away.

### DIFF
--- a/core/puppeteer.js
+++ b/core/puppeteer.js
@@ -13,7 +13,9 @@ const getBrowserInstance = async (port) => {
     devtools: !IS_PROD,
     executablePath: IS_PROD ? '/usr/bin/chromium-browser' : undefined,
   });
-  return browser.createIncognitoBrowserContext();
+  const incognitoBrowserContext = browser.createIncognitoBrowserContext();
+  incognitoBrowserContext.close = browser.close;
+  return incognitoBrowserContext;
 };
 
 module.exports = {


### PR DESCRIPTION
Sweeping used browser instances instead of just the incognitoContext