### PR TITLE
[Bugfix] Handle Page Crash Error.

### DIFF
--- a/services/youtubeBrowser.service.js
+++ b/services/youtubeBrowser.service.js
@@ -17,6 +17,7 @@ const viewVideosInBatch = async ({ targetUrls, durationInSeconds, port }) => {
     browser = await puppeteer.getBrowserInstance(port);
     const page = await browser.newPage();
     page.setDefaultTimeout(PAGE_DEFAULT_TIMEOUT * 1000);
+    page.on('error', msg => { throw msg }); // https://github.com/puppeteer/puppeteer/issues/3709
     await page.setViewport({
       width: 640,
       height: 480,


### PR DESCRIPTION
throw page errors which can then be caught and the browser closed.