### PR TITLE
Bypassing Content Security Policy 😎

### DIFF
--- a/services/youtubeBrowser.service.js
+++ b/services/youtubeBrowser.service.js
@@ -22,6 +22,7 @@ const viewVideosInBatch = async ({ targetUrls, durationInSeconds, port }) => {
   try {
     browser = await puppeteer.getBrowserInstance(port);
     const page = await browser.newPage();
+    await page.setBypassCSP(true);
     page.setDefaultTimeout(PAGE_DEFAULT_TIMEOUT * 1000);
     page.on('error', handlePageCrash(page));
     page.on('pageerror', handlePageCrash(page));


### PR DESCRIPTION
Adding `Page.setBypassCSP(true)` at page initialization stage, will allow solve this `Error: EvalError: Refused to evaluate a string as JavaSctipt because 'unsafe-eval' is not allowed source...` for issue #21